### PR TITLE
Prepare repository for archiving

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -18,7 +18,22 @@ const config: StorybookConfig = {
         // see: https://vitejs.dev/config/server-options.html#server-watch
         // setting it to anything other than dist fixes the issue
         outDir: 'dist-vite'
-      }
+      },
+      plugins: [
+        {
+          // Storybook 10 accepts HMR updates for preview.ts (and its transitive deps like the
+          // Stencil loader) at the project-annotations boundary. That soft re-render cannot pick
+          // up rebuilt Stencil components because custom elements cannot be redefined, so force
+          // the full page reload that Storybook <= 9 used to do.
+          name: 'stencil-force-full-reload',
+          handleHotUpdate({ file, server }) {
+            if (file.includes('/dist/')) {
+              server.ws.send({ type: 'full-reload' })
+              return []
+            }
+          }
+        }
+      ]
     })
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Stencil Storybook Vite Starter
 
+> [!IMPORTANT]
+> **This repository is archived.** Stencil now ships an official Storybook integration,
+> [`@stencil/storybook-plugin`](https://www.npmjs.com/package/@stencil/storybook-plugin), which supports
+> Storybook 10, compiles components inside the Storybook pipeline (no manual build orchestration or
+> hot-reload workarounds) and generates controls/docs from component metadata. Use it instead of this
+> starter — see the [Stencil Storybook docs](https://stenciljs.com/docs/storybook).
+>
+> This repo remains available as a reference for a different setup: rendering Stencil's **built `dist/`
+> output** through the lazy loader (the artifact consumers actually install) in Storybook, with stories
+> written in Lit against the plain custom-element API. Everything works as of Storybook 10.5 /
+> Stencil 4.43 / Vite 7.
+
 This is a starter project for building a standalone Web Component using Stencil and Storybook for Web-Components with Vite.
 
 This project utilizes [Google Wireit](https://github.com/google/wireit) for efficient build management and dev server


### PR DESCRIPTION
## Summary

Prepares the repo for archiving in a working state:

- **fix: restore hot reloading with Storybook 10** — Storybook 10's Vite builder accepts HMR updates for `preview.ts` (and its transitive deps, i.e. the Stencil loader / `dist/` chain) at the new `project-annotations` virtual module boundary. That soft re-render can't pick up rebuilt Stencil components because custom elements cannot be redefined, so the story kept rendering the stale component. A small Vite plugin in `viteFinal` now forces the full page reload that Storybook ≤ 9 performed for changes under `dist/`. Verified end-to-end (edit component source → Stencil rebuild → browser reloads with new render in ~1s). Story-file edits keep normal Storybook HMR.
- **docs: add archive notice** — points to the official [`@stencil/storybook-plugin`](https://www.npmjs.com/package/@stencil/storybook-plugin) (supports Storybook 10) as the successor, and documents what this repo still demonstrates (rendering the built `dist/` output through the lazy loader).

After merging, archive the repository in the GitHub settings.